### PR TITLE
Fix Authorization Header

### DIFF
--- a/coconut/job.py
+++ b/coconut/job.py
@@ -15,7 +15,9 @@ def get_authorization_header(api_key):
   if api_key is None:
     raise ValueError('API key must be specified using the api_key parameter or the COCONUT_API_KEY environment variable')
 
-  return 'Basic ' + base64.b64encode('%s:' % api_key)
+  api_key = api_key + ":"
+  data_bytes = api_key.encode("utf-8")
+  return 'Basic ' + base64.b64encode(data_bytes).decode("utf-8")
 
 def submit(config_content, **kwargs):
   h = httplib2.Http()

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def read(*paths):
         return f.read()
 setup(
   name = 'coconutpy',
-  version = '2.4.2',
+  version='2.4.3',
   py_modules = ['coconut.job', 'coconut.config'],
   packages=find_packages(exclude=['tests*']),
   author='Bruno Celeste',
@@ -28,6 +28,10 @@ For more information:
 * Twitter: @openCoconut
 
 Changelogs
+
+2.4.3
+Fix Authorization Header: 
+"TypeError: a bytes-like object is required, not 'str'" was returned before
 
 2.4.2
 Don't wait for a 401 challenge to pass the auth token to Coconut APIs.

--- a/tests.py
+++ b/tests.py
@@ -7,7 +7,8 @@ import time
 API_KEY_PARAM = None
 
 class CoconutTestCase(unittest.TestCase):
-
+    @unittest.skipIf(API_KEY_PARAM is None,
+                   'To run this test, set API_KEY_PARAM, but do not commit it to the repo.')
     def test_submit_job(self):
       conf = coconut.config.new(
         source='https://s3-eu-west-1.amazonaws.com/files.coconut.co/test.mp4',
@@ -16,7 +17,7 @@ class CoconutTestCase(unittest.TestCase):
       )
 
       job = coconut.job.submit(conf)
-      self.assertEqual("ok", job["status"])
+      self.assertEqual("processing", job["status"])
       self.assertTrue(job["id"] > 0)
 
     @unittest.skipIf(API_KEY_PARAM is None, 
@@ -29,7 +30,7 @@ class CoconutTestCase(unittest.TestCase):
       )
 
       job = coconut.job.submit(conf, api_key=API_KEY_PARAM)
-      self.assertEqual("ok", job["status"])
+      self.assertEqual("processing", job["status"])
       self.assertTrue(job["id"] > 0)
 
     def test_submit_bad_config(self):
@@ -109,7 +110,7 @@ class CoconutTestCase(unittest.TestCase):
         vars={'vid': 1234, 'user': 5098}
       )
 
-      self.assertEqual("ok", job["status"])
+      self.assertEqual("processing", job["status"])
       self.assertTrue(job["id"] > 0)
 
       os.remove('coconut.conf')


### PR DESCRIPTION
Changes:
 - Fixes "TypeError: a bytes-like object is required, not 'str'" error
 - Fixes few existing tests: job is retruning 'processing' instead of 'ok'
 - Bumps version to 2.4.3